### PR TITLE
Nit Permit() test

### DIFF
--- a/contracts/KaliDAOtoken.sol
+++ b/contracts/KaliDAOtoken.sol
@@ -194,6 +194,8 @@ abstract contract KaliDAOtoken {
 
         // cannot realistically overflow on human timescales
         unchecked {
+            uint256 _nonce = nonces[owner] + 1;
+
             bytes32 digest = keccak256(
                 abi.encodePacked(
                     '\x19\x01',

--- a/contracts/KaliDAOtoken.sol
+++ b/contracts/KaliDAOtoken.sol
@@ -194,13 +194,11 @@ abstract contract KaliDAOtoken {
 
         // cannot realistically overflow on human timescales
         unchecked {
-            uint256 _nonce = nonces[owner] + 1;
-
             bytes32 digest = keccak256(
                 abi.encodePacked(
                     '\x19\x01',
                     DOMAIN_SEPARATOR(),
-                    keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, _nonce, deadline))
+                    keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, nonces[owner]++, deadline))
                 )
             );
 

--- a/contracts/KaliDAOtoken.sol
+++ b/contracts/KaliDAOtoken.sol
@@ -200,7 +200,7 @@ abstract contract KaliDAOtoken {
                 abi.encodePacked(
                     '\x19\x01',
                     DOMAIN_SEPARATOR(),
-                    keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, nonces[owner]++, deadline))
+                    keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, _nonce, deadline))
                 )
             );
 

--- a/test/KaliDAO.test.js
+++ b/test/KaliDAO.test.js
@@ -1566,7 +1566,7 @@ describe("KaliDAO", function () {
       verifyingContract: kali.address,
     }
     const types = {
-      PERMIT_TYPEHASH: [
+      Permit: [
         { name: "owner", type: "address" },
         { name: "spender", type: "address" },
         { name: "value", type: "uint256" },
@@ -1578,14 +1578,40 @@ describe("KaliDAO", function () {
       owner: proposer.address,
       spender: bob.address,
       value: getBigNumber(1),
-      nonce: 0,
+      nonce: 1,
       deadline: 1941543121
     }
 
     const signature = await proposer._signTypedData(domain, types, value)
     const { r, s, v } = ethers.utils.splitSignature(signature)
+    
+    await kali.permit(proposer.address, bob.address, getBigNumber(1), 1941543121, v, r, s)
 
-    kali.permit(proposer.address, bob.address, getBigNumber(1), 1941543121, v, r, s)
+    // Unpause to unblock transferFrom
+    await kali.propose(7, "TEST", [proposer.address], [0], [0x00])
+    await kali.vote(1, true)
+    await advanceTime(35)
+    await kali.processProposal(1)
+    expect(await kali.paused()).to.equal(false)
+
+    // console.log(
+    //   "Proposer's balance before delegation: ",
+    //   await kali.balanceOf(proposer.address)
+    // )
+    // console.log(
+    //   "Bob's balance before delegation: ",
+    //   await kali.balanceOf(bob.address)
+    // )
+    await kali.connect(bob).transferFrom(proposer.address, bob.address, getBigNumber(1))
+    // console.log(
+    //   "Proposer's balance after delegation: ",
+    //   await kali.balanceOf(proposer.address)
+    // )
+    // console.log(
+    //   "Bob's balance after delegation: ",
+    //   await kali.balanceOf(bob.address)
+    // )
+    expect(await kali.balanceOf(bob.address)).to.equal(getBigNumber(1))
   })
   it("permit should revert if the signature is invalid", async () => {
     await kali.init(

--- a/test/KaliDAO.test.js
+++ b/test/KaliDAO.test.js
@@ -1578,7 +1578,7 @@ describe("KaliDAO", function () {
       owner: proposer.address,
       spender: bob.address,
       value: getBigNumber(1),
-      nonce: 1,
+      nonce: 0,
       deadline: 1941543121
     }
 


### PR DESCRIPTION
Context
- Nit after noticing `permit should work if the signature is valid` test throws InvalidSignature() via subtext even though it passes test (see below).. not sure why it passes in the first place

<img width="682" alt="Screenshot 2022-01-07 215247" src="https://user-images.githubusercontent.com/5264156/148631771-ce1fbaa4-5bd0-4f1e-bda4-3695916fc02d.png">

~~KaliDAOtoken.sol~~
~~- Update input parameter to `digest` in permit() as `nonces[owner]++` throws InvalidSignature()~~

KaliDAO.test.js
- Update "permit should work if the signature is valid" test logic with expect() to validate expected test result