### PR TITLE
Update KaliDAO.sol

### DIFF
--- a/contracts/KaliDAO.sol
+++ b/contracts/KaliDAO.sol
@@ -324,7 +324,7 @@ contract KaliDAO is KaliDAOtoken, Multicall, NFThelper, ReentrancyGuard {
             
         address recoveredAddress = ecrecover(digest, v, r, s);
 
-        if (recoveredAddress != signer) revert InvalidSignature();
+        if (recoveredAddress == address(0) || recoveredAddress != signer) revert InvalidSignature();
         
         _vote(signer, proposal, approve);
     }


### PR DESCRIPTION
Add security check to `voteBySig()` per [EIP-2612](https://eips.ethereum.org/EIPS/eip-2612) (`Since the ecrecover precompile fails silently and just returns the zero address as signer when given malformed messages, it is important to ensure owner != address(0) to avoid permit from creating an approval to spend “zombie funds” belong to the zero address`)